### PR TITLE
Infected will return true to IsNPC() calls

### DIFF
--- a/lua/entities/nb_ba2_infected.lua
+++ b/lua/entities/nb_ba2_infected.lua
@@ -142,6 +142,8 @@ function ENT:Initialize()
 			end
 		end)
 	end
+	
+	getmetatable(self).IsNPC = function() return true end -- IsNPC() will return true, so other addons see us as NPCs and not just nextbots
 	--self:CallOnRemove("KillSounds",function() self:KillSounds() end)
 end
 
@@ -1207,6 +1209,16 @@ end
 -- Error handling
 function ENT:GetActiveWeapon()
 	return NULL
+end
+
+-- If anyone wants a desposition, it's hatred
+function ENT:Disposition(ent)
+	return D_HT
+end
+
+-- We hate everyone anyways, so anyone else calling this should just be discarded
+function ENT:AddEntityRelationship(target, disposition, priority) 
+
 end
 
 -- Hello from the past -Sninctbur


### PR DESCRIPTION
This change helps improve compatibility with other addons. For example, it allows JMod sentries to shoot at Infected.

A potential concern with this is other addons attempting to call NPC-related functions on the Infected that don't exist -- if need be, these functions can be stubbed out.
